### PR TITLE
DocLang v1.0.1 - minor bug fixes and improvements.

### DIFF
--- a/DocLang.Shell/DocLang.Shell.csproj
+++ b/DocLang.Shell/DocLang.Shell.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>doclang</ToolCommandName>
@@ -12,6 +12,7 @@
 		<RootNamespace>BassClefStudio.DocLang.Shell</RootNamespace>
 
 		<PackageId>DocLang.Shell</PackageId>
+		<Version>1.0.1</Version>
 		<Authors>BassClefStudio</Authors>
 		<Description>An XML-based markup language that can be used for everything from notes to websites. The Shell package provides a CLI tool that can be used to compile DocLang content to a variety of platforms and formats.</Description>
 		<PackageProjectUrl>https://github.com/bassclefstudio/DocLang</PackageProjectUrl>

--- a/DocLang.Shell/Program.cs
+++ b/DocLang.Shell/Program.cs
@@ -1,8 +1,5 @@
 ﻿using BassClefStudio.Storage;
-using BassClefStudio.DocLang.Web;
-using BassClefStudio.DocLang.Xml;
 using System.CommandLine;
-using System.Net.Mime;
 using BassClefStudio.DocLang.Base;
 using BassClefStudio.Storage.Base;
 

--- a/DocLang/Base/BaseFormats.cs
+++ b/DocLang/Base/BaseFormats.cs
@@ -1,5 +1,3 @@
-
-using System.Collections.Generic;
 using System.Net.Mime;
 using BassClefStudio.DocLang.Web;
 using BassClefStudio.DocLang.Xml;

--- a/DocLang/Base/RawDocValidator.cs
+++ b/DocLang/Base/RawDocValidator.cs
@@ -1,6 +1,3 @@
-using System.Net.Mime;
-using System.Reflection.Metadata;
-
 namespace BassClefStudio.DocLang.Base;
 
 /// <summary>

--- a/DocLang/DocLang.csproj
+++ b/DocLang/DocLang.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>BassClefStudio.DocLang</RootNamespace>
 
     <PackageId>DocLang</PackageId>
+	  <Version>1.0.1</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An XML-based markup language that can be used for everything from notes to websites.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/DocLang</PackageProjectUrl>

--- a/DocLang/DocLang.csproj
+++ b/DocLang/DocLang.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BassScript" Version="1.0.0" />
+    <PackageReference Include="BassScript" Version="1.0.1" />
     <PackageReference Include="Pidgin" Version="3.1.0" />
     <PackageReference Include="StorageLib" Version="1.0.0" />
   </ItemGroup>

--- a/DocLang/IContentResolver.cs
+++ b/DocLang/IContentResolver.cs
@@ -1,10 +1,4 @@
 ﻿using BassClefStudio.BassScript.Runtime;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 using System.Xml.Linq;
 
 namespace BassClefStudio.DocLang

--- a/DocLang/Web/Config-v1.xsd
+++ b/DocLang/Web/Config-v1.xsd
@@ -149,7 +149,7 @@
                 </xs:attribute>
 				<xs:attribute name="Key" type="xs:string">
 					<xs:annotation>
-						<xs:documentation>A friendly key for the page in question. Defaults to the destination path.</xs:documentation>
+						<xs:documentation>A friendly key for the page in question. Defaults to the name of the body if not specified (or, if the body is also null, the name of the template in use).</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
             </xs:extension>

--- a/DocLang/Web/Config-v1.xsd
+++ b/DocLang/Web/Config-v1.xsd
@@ -115,7 +115,7 @@
     </xs:complexType>
 
     <xs:complexType name="Constant">
-        <xs:simpleContent>
+        <xs:complexContent>
             <xs:annotation>
                 <xs:documentation>A string constant value which can be referenced by any page or template.</xs:documentation>
             </xs:annotation>
@@ -126,7 +126,7 @@
                     </xs:annotation>
                 </xs:attribute>
             </xs:extension>
-        </xs:simpleContent>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="Page">
@@ -147,6 +147,11 @@
                         <xs:documentation>The relative path in the output folder where the webpage should be saved.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+				<xs:attribute name="Key" type="xs:string">
+					<xs:annotation>
+						<xs:documentation>A friendly key for the page in question. Defaults to the destination path.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/DocLang/Web/SiteContentResolver.cs
+++ b/DocLang/Web/SiteContentResolver.cs
@@ -1,19 +1,7 @@
-﻿using BassClefStudio.DocLang.Web.Sites;
-using BassClefStudio.DocLang.Xml;
-using BassClefStudio.Storage;
-using BassClefStudio.BassScript.Parsers;
+﻿using BassClefStudio.BassScript.Parsers;
 using BassClefStudio.BassScript.Runtime;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 using System.Xml.Linq;
-using Pidgin;
-using static Pidgin.Parser;
-using static Pidgin.Parser<char>;
 using BassClefStudio.BassScript.Data;
 using System.Text.RegularExpressions;
 

--- a/DocLang/Web/Sites/Asset.cs
+++ b/DocLang/Web/Sites/Asset.cs
@@ -1,9 +1,4 @@
 ﻿using BassClefStudio.Storage;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BassClefStudio.BassScript.Runtime;
 
 namespace BassClefStudio.DocLang.Web.Sites

--- a/DocLang/Web/Sites/Page.cs
+++ b/DocLang/Web/Sites/Page.cs
@@ -1,4 +1,3 @@
-using BassClefStudio.BassScript.Runtime;
 using BassClefStudio.Storage;
 
 namespace BassClefStudio.DocLang.Web.Sites;

--- a/DocLang/Web/Sites/Site.cs
+++ b/DocLang/Web/Sites/Site.cs
@@ -1,11 +1,4 @@
-﻿using BassClefStudio.BassScript.Runtime;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BassClefStudio.DocLang.Web.Sites
+﻿namespace BassClefStudio.DocLang.Web.Sites
 {
     /// <summary>
     /// Represents all of the contained data that makes up a compiled DocLang website.

--- a/DocLang/Web/Sites/StyleSheet.cs
+++ b/DocLang/Web/Sites/StyleSheet.cs
@@ -1,9 +1,4 @@
 ﻿using BassClefStudio.Storage;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BassClefStudio.DocLang.Web.Sites
 {

--- a/DocLang/Web/Sites/Template.cs
+++ b/DocLang/Web/Sites/Template.cs
@@ -1,11 +1,8 @@
-using System.Collections.Generic;
 using System.Net.Mime;
 using System.Xml.Linq;
 using BassClefStudio.BassScript.Runtime;
-using BassClefStudio.DocLang.Base;
 using BassClefStudio.DocLang.Xml;
 using BassClefStudio.Storage;
-using CommunityToolkit.Diagnostics;
 
 namespace BassClefStudio.DocLang.Web.Sites;
 

--- a/DocLang/Web/WebSiteBuilder.cs
+++ b/DocLang/Web/WebSiteBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Net.Mime;
 using BassClefStudio.Storage;
 using System.Xml.Linq;
@@ -272,6 +272,7 @@ namespace BassClefStudio.DocLang.Web
                     }
                     else
                     {
+                        string name = page.Attribute("Name")?.Value ?? path;
                         string? templateName = page.Attribute("Template")?.Value;
                         if (string.IsNullOrEmpty(templateName))
                         {
@@ -289,7 +290,7 @@ namespace BassClefStudio.DocLang.Web
                             IDictionary<string, object?> propDict =
                                 await ResolveConfigObject(page, context) as IDictionary<string, object?> ??
                                 new Dictionary<string, object?>();
-                            group.Pages[path] = new Page(
+                            group.Pages[name] = new Page(
                                 destinationFile,
                                 path,
                                 resolver,

--- a/DocLang/Xml/DocLangValidator.cs
+++ b/DocLang/Xml/DocLangValidator.cs
@@ -1,7 +1,4 @@
-﻿using System.Xml;
-using System.Xml.Schema;
-
-namespace BassClefStudio.DocLang.Xml
+﻿namespace BassClefStudio.DocLang.Xml
 {
     /// <summary>
     /// Provides an <see cref="IDocValidator"/> for base DocLang XML files.

--- a/DocLang/Xml/DocLangXml.cs
+++ b/DocLang/Xml/DocLangXml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Mime;
-using System.Xml;
 
 namespace BassClefStudio.DocLang.Xml
 {


### PR DESCRIPTION
Release notes:
- When creating a constant inside of a Site with properties (a complex object), a `RuntimeObject` (from [BassScript v1.0.1](https://github.com/bassclefstudio/BassScript/pull/2)) is generated instead of (as previously) an `IDictionary<string, object?>`. This should prevent complex constants referencing each other from being 
- New `Key` attribute to all `Page` elements in `site-config.xml` allows for specifying the specific key used by a given `Page` (enabling ease of access by expression). This key defaults to the provided `Body` or `Template` values (as strings) if not specified.